### PR TITLE
[feat]: Add scroll-to-top button in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Button } from "./ui/button";
 import { ThemeButton } from "./ui/theme-btn";
+import { ScrollToTop } from "./ScrollToTop";//Import Scroll to Top component
 
 const Footer = () => {
   const [isChatOpen, setIsChatOpen] = useState(false);
@@ -58,7 +59,8 @@ const Footer = () => {
           </Button>
         </div>
       </div>
-
+      {/* Add scroll to top component */}
+      <ScrollToTop/>
       {/* Chat Component - Toggle Visibility */}
       {isChatOpen && <CardsChat />}
     </footer>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState,useEffect } from 'react'
+import { ArrowBigUp } from 'lucide-react'
+import React from 'react'
+
+export function ScrollToTop() {
+  const [isVisible, setVisible]=useState(true)
+  useEffect(() => {
+    const toggleVisibility=()=>{
+    if(window.scrollY > 200){
+      setVisible(true)
+    }
+    else{
+      setVisible(false)
+    }
+  } 
+    window.addEventListener('scroll', toggleVisibility)
+  
+    return () => {
+    window.removeEventListener('scroll', toggleVisibility)
+    }
+  }, [])
+  const handleScroll=()=>{
+    window.scrollTo({top:0, behavior:"smooth"})
+  }
+
+  return (
+    <button className={`fixed bottom-16 right-6 shadow-lg p-3 z-99 rounded-full flex justify-center items-center cursor-pointer bg-purple-600 dark:bg-purple-600 hover:bg-purple-700'
+    ${isVisible ? 'opacity-100 translate-y-0':'opacity-0 translate-y-16 pointer-events-none'} transition-all duration-500`}
+    onClick={handleScroll}>
+    <ArrowBigUp className='text-white' size={32}/>
+    </button>
+  )
+}
+


### PR DESCRIPTION
## Title
This PR adds a scroll-to-top button in the footer.
The button allows users to return to the top of the page smoothly, with animation.
It is styled to match the current UI and is reusable.

## Related issue
closes #39 

## Additional Information
- There is already an error in package.json (not caused by this PR).
- Some other components have lint errors, but this button code has no lint issues.
- If it’s helpful, I’d be happy to create a separate PR to fix the package.json issue and address those lint errors.
